### PR TITLE
[feature] api 재정비

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -10,8 +10,6 @@ import { UsersModule } from './users/users.module';
 import { TasksModule } from './tasks/tasks.module';
 import { join } from 'path';
 
-
-
 @Module({
   imports: [
     GimpsModule,

--- a/src/gimps/gimp.entity.ts
+++ b/src/gimps/gimp.entity.ts
@@ -2,7 +2,7 @@ import { Entity, Column, PrimaryColumn } from 'typeorm';
 
 @Entity()
 export class Gimp {
-  @PrimaryColumn()
+  @PrimaryColumn({ type: 'timestamptz' })
   datetime: Date;
 
   @Column('decimal', { precision: 9, scale: 0, nullable: true})

--- a/src/gimps/gimps.controller.ts
+++ b/src/gimps/gimps.controller.ts
@@ -8,13 +8,8 @@ import { GimpsService } from './gimps.service'
 export class GimpsController {
   constructor(private gimpService: GimpsService) {}
 
-  @Post()
-  create(@Body() body: Gimp) {
-    return this.gimpService.create(body);
-  }
-
   @Get()
-  findByDateRange(@Query() query: DateRangeDto): Promise<Gimp[]> {
-    return this.gimpService.findByDateRange(query);
+  async findByDateRange(@Query() query: DateRangeDto): Promise<Gimp[]> {
+    return await this.gimpService.findByDateRange(query);
   }
 }

--- a/src/gimps/gimps.service.ts
+++ b/src/gimps/gimps.service.ts
@@ -20,7 +20,7 @@ export class GimpsService {
       .insert()
       .into(Gimp)
       .values({
-        datetime: moment(newbie.datetime).format("YYYY-MM-DD HH:mm:ss").toString(),
+        datetime: moment(newbie.datetime).toISOString(),
         bitmex_price: newbie.bitmex_price,
         upbit_price: newbie.upbit_price,
         gimp: newbie.gimp,
@@ -43,14 +43,15 @@ export class GimpsService {
 
   async findByDateRange(dateRagne: DateRangeDto): Promise<Gimp[]> {
 
-    const from: string = moment(dateRagne.from).toISOString();
-    const to: string = moment(dateRagne.to).toISOString();
+    const from = moment(dateRagne.from);
+    const to = moment(dateRagne.to);
 
-    return await this.gimpRepository
+    return this.gimpRepository
       .createQueryBuilder()
       .select()
-      .andWhere(`datetime >= '${from}'`)
-      .andWhere(`datetime < '${to}'`)
+      .andWhere(`datetime >= '${from.toISOString()}'`)
+      .andWhere(`datetime < '${to.toISOString()}'`)
+      .orderBy('datetime', 'ASC')
       .getMany()
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,13 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { types } from 'pg'
 
 async function bootstrap() {
+
+  types.setTypeParser(1700, function(val) {
+    return parseFloat(val);
+  });
+
   const app = await NestFactory.create(AppModule);
   await app.listen(3000, '0.0.0.0');
 }

--- a/src/migrations/1598546055457-ChangeTimezoneColumn.ts
+++ b/src/migrations/1598546055457-ChangeTimezoneColumn.ts
@@ -1,0 +1,20 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class ChangeTimezoneColumn1598546055457 implements MigrationInterface {
+    name = 'ChangeTimezoneColumn1598546055457'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "gimp" DROP CONSTRAINT "PK_9a0bf26e81a50069230a74c9755"`);
+        await queryRunner.query(`ALTER TABLE "gimp" DROP COLUMN "datetime"`);
+        await queryRunner.query(`ALTER TABLE "gimp" ADD "datetime" TIMESTAMP WITH TIME ZONE NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "gimp" ADD CONSTRAINT "PK_9a0bf26e81a50069230a74c9755" PRIMARY KEY ("datetime")`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "gimp" DROP CONSTRAINT "PK_9a0bf26e81a50069230a74c9755"`);
+        await queryRunner.query(`ALTER TABLE "gimp" DROP COLUMN "datetime"`);
+        await queryRunner.query(`ALTER TABLE "gimp" ADD "datetime" TIMESTAMP NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "gimp" ADD CONSTRAINT "PK_9a0bf26e81a50069230a74c9755" PRIMARY KEY ("datetime")`);
+    }
+
+}

--- a/src/users/dto/create-user.dto.ts
+++ b/src/users/dto/create-user.dto.ts
@@ -1,0 +1,12 @@
+export class CreateUserDto {
+  buy_target_gimp: number;
+  sell_target_gimp: number;
+  krw_trade_amount: number;
+  state: TradingState
+}
+
+enum TradingState {
+  SLEEP = 'SLEEP',
+  BUY = 'BUY',
+  SELL = 'SELL'
+}

--- a/src/users/dto/update-user.dto.ts
+++ b/src/users/dto/update-user.dto.ts
@@ -1,0 +1,12 @@
+export class UpdateUserDto {
+  buy_target_gimp?: number;
+  sell_target_gimp?: number;
+  krw_trade_amount?: number;
+  state?: TradingState
+}
+
+enum TradingState {
+  SLEEP = 'SLEEP',
+  BUY = 'BUY',
+  SELL = 'SELL'
+}

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,22 +1,43 @@
-import { Controller, Post, Body, Put, Param } from '@nestjs/common';
+import { Controller, Post, Body, Put, Param, Get } from '@nestjs/common';
 import { User } from './user.entity';
 import { UsersService } from './users.service';
+
+import { CreateUserDto } from './dto/create-user.dto'
+import { UpdateUserDto } from './dto/update-user.dto'
+
 
 
 @Controller('api/users')
 export class UsersController {
   constructor(private userService: UsersService) {}
 
-  @Post()
-  async create(@Body() body: User): Promise<User> {
-    await this.userService.create(body);
-    return body
+  @Get(':id')
+  async show(@Param('id') id: number): Promise<User> {
+    try {
+      return await this.userService.findById(id)
+    } catch (err) {
+      throw new Error(err)
+    }
   }
 
-  // @Put(':id')
-  // update(@Param('id') id: string, @Body() body: User) {
-  //   await this.userService.updateUser(body)
-  //   return 
-  // }
+  @Post()
+  async create(@Body() body: CreateUserDto): Promise<User> {
+    try {
+      return await this.userService.create(body);
+    }
+    catch(err) {
+      throw new Error(err)
+    }
+  }
+
+  @Put(':id')
+  async update(@Param('id') id: number, @Body() body: UpdateUserDto): Promise<User> {
+    try {
+      return await this.userService.updateUser(id, body);
+    }
+    catch(err) {
+      throw new Error(err)
+    }
+  }
 
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -2,6 +2,8 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { User } from './user.entity';
+import { CreateUserDto } from './dto/create-user.dto'
+import { UpdateUserDto } from './dto/update-user.dto'
 
 @Injectable()
 export class UsersService {
@@ -10,21 +12,27 @@ export class UsersService {
     private userRepository: Repository<User>,
   ) {}
 
-  async create(newbie: User) :Promise<any>{
-    await this.userRepository
-      .createQueryBuilder()
-      .insert()
-      .into(User)
-      .values(newbie)
-      .execute();
+  async create(newbie: CreateUserDto) :Promise<User>{
+    return this.userRepository.save({
+      ...newbie,
+      btc_trade_amount: 0
+    });
   }
   async findById(id: number) :Promise<any>{
-    return await this.userRepository
+    return this.userRepository
       .findOne({id: id})
   }
 
-  async updateUser(updateUser: User) :Promise<any>{
-    await this.userRepository
-    .save(updateUser)
+  async updateUser(id: number, param: UpdateUserDto) :Promise<User> {
+    const user: User = await this.userRepository.findOne({id: id})
+    const toUpdate: User = Object.assign(user, param)
+
+    return this.userRepository.save(toUpdate)
+  }
+
+  async stateTransition(user: User, btc_trade_amount: number, state: string) :Promise<any> {
+    user.btc_trade_amount = btc_trade_amount
+    user.state = state
+    await this.userRepository.save(user)
   }
 }


### PR DESCRIPTION
- migration needed! -> Datetime column to Timestamp with Timezone (기존것은 타임존 없었음)
- Gimp List api 타임존 고려 재정비 및 ISOString 지원
- User API 재정비

Alert : BigInt로 처리되는 부분들은 Response에서 String으로 처리되어 보여짐 아래처럼 id를 제외한 bigInt Column들이 스트링형태로 나옴 typeorm 자체 드라이버 문제라 어떻게할지 고민해봐야함.
일관되게 string이면 상관이없는데, update 시 update object는 number 로 처리되어 업데이트하는 컬럼은 number, 아닌것은 string으로 나오는 비균일 증상 발생
{
    "id": 1,
    "buy_target_gimp": "0.100",
    "sell_target_gimp": "-0.100",
    "krw_trade_amount": "370000",
    "btc_trade_amount": "0",
    "state": "SLEEP"
}
-> 해결

