### PR TITLE
[Update] findByDateRange function

### DIFF
--- a/src/gimps/gimps.service.ts
+++ b/src/gimps/gimps.service.ts
@@ -42,16 +42,27 @@ export class GimpsService {
   }
 
   async findByDateRange(dateRagne: DateRangeDto): Promise<Gimp[]> {
-
-    const from = moment(dateRagne.from);
+    
+    const from = dateRagne.from ? moment(dateRagne.from) : undefined;
     const to = moment(dateRagne.to);
 
-    return this.gimpRepository
+    if (from) {
+      return this.gimpRepository
       .createQueryBuilder()
       .select()
+      .where(`datetime <= '${to.toISOString()}'`)
       .andWhere(`datetime >= '${from.toISOString()}'`)
-      .andWhere(`datetime < '${to.toISOString()}'`)
-      .orderBy('datetime', 'ASC')
+      .orderBy('datetime', 'DESC')
       .getMany()
+    }
+    else {
+      return this.gimpRepository
+      .createQueryBuilder()
+      .select()
+      .where(`datetime <= '${to.toISOString()}'`)
+      .orderBy('datetime', 'DESC')
+      .limit(1)
+      .getMany()
+    }
   }
 }


### PR DESCRIPTION
- ASC -> DESC
- reverse를 넣고 싶었으나 실패. orderby의 자리에 typedl "ASC"||"DESC"으로 지정되어 있어서 그거에 맞춰야함
- request query에서 from을 안주면 gimp Data 한개만 가져오게 함수 변경. to는 안주면 현재시간으로 됨(원래부터)
- datetime < to  에서 datetime <= to로 변경 